### PR TITLE
docs: fix dead link to Camunda Connector Runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Run unit tests
 mvn clean verify
 ```
 
-Use the [Camunda Job Worker Connector Run-Time](https://github.com/camunda/connector-framework/tree/main/runtime-job-worker) to run your function as a local Job Worker.
+Use the [Camunda Connector Runtime](https://github.com/camunda-community-hub/spring-zeebe/tree/master/connector-runtime#building-connector-runtime-bundles) to run your function as a local Job Worker.
 
 ## Element Template
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Fixes the link in [`README.md`](https://github.com/camunda-community-hub/camunda-8-connector-openweather-api/blob/aa76662744cab46056d1e9eb4ce612b613ddce59/README.md?plain=1#L47) to [Camunda Connector Runtime](https://github.com/camunda-community-hub/spring-zeebe/tree/master/connector-runtime#building-connector-runtime-bundles). This is similar to:
- camunda/connector-sendgrid#139
- camunda/connector-slack#139
- camunda/connector-google-drive#113
## Related issues

<!-- Which issues are closed by this PR or are related -->
No related issue.

