### PR TITLE
Updated connectors runtime Docker tag

### DIFF
--- a/docker.sh
+++ b/docker.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker run --rm --name=connectors -v $PWD/target/openweather-api-0.1.0-SNAPSHOT.jar:/opt/app/connector.jar --env-file env.txt camunda/connectors:0.2.0
+docker run --rm --name=connectors -v $PWD/target/openweather-api-0.1.0-SNAPSHOT.jar:/opt/app/connector.jar --env-file env.txt camunda/connectors:0.7.0


### PR DESCRIPTION
Upped from 0.2.0 or 0.7.0

Description
Updated the connector runtime Docker tag from 0.2.0 to 0.7.0.

Related issues
No related issues, but 0.2.0 does not work and is out of date.

